### PR TITLE
fix: RegExp separator

### DIFF
--- a/actions/store_message_params_MOD.js
+++ b/actions/store_message_params_MOD.js
@@ -200,9 +200,9 @@ module.exports = {
         break
       case 1:
         if (data.count) {
-          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).slice(0, count).join(separator) || undefined
+          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).slice(0, count).join(' ') || undefined
         } else {
-          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).join(separator) || undefined
+          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).join(' ') || undefined
         }
         break
       case 2:

--- a/actions/store_message_params_MOD.js
+++ b/actions/store_message_params_MOD.js
@@ -200,9 +200,9 @@ module.exports = {
         break
       case 1:
         if (data.count) {
-          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).slice(0, count).join(new RegExp(separator, 'g')) || undefined
+          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).slice(0, count).join(separator) || undefined
         } else {
-          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).join(new RegExp(separator, 'g')) || undefined
+          result = msg.content.split(new RegExp(separator, 'g')).slice(ParamN).join(separator) || undefined
         }
         break
       case 2:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixed RegExp separator being instantiated to join, causing some really weird joining.

**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
