### PR TITLE
fix(mods): attach file to embed, V12 compatibility

### DIFF
--- a/actions/edit_embed_object_MOD.js
+++ b/actions/edit_embed_object_MOD.js
@@ -578,7 +578,7 @@ module.exports = {
         embed.image = undefined
         break
       case 3:
-        embed.attachFile(`${imageUrl}/${imageUrl2}`)
+        embed.attachFiles([`${imageUrl}/${imageUrl2}`])
         embed.setImage(`attachment://${imageUrl2}`)
         break
     }
@@ -590,7 +590,7 @@ module.exports = {
         embed.thumbnail = undefined
         break
       case 3:
-        embed.attachFile(`${thumbUrl}/${thumbUrl2}`)
+        embed.attachFiles([`${thumbUrl}/${thumbUrl2}`])
         embed.setImage(`attachment://${thumbUrl2}`)
         break
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Documentation can be seen [here](https://discord.js.org/#/docs/main/stable/class/MessageEmbed?scrollTo=attachFiles). 
Reported in the [Discord](https://discordapp.com/channels/374961173524643843/728008557190184971/745203037697605692).

**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [X] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
