### PR TITLE
fix: event destroying the bot process and subtitles for Store Attachment Info

### DIFF
--- a/actions/store_attachment_info_MOD.js
+++ b/actions/store_attachment_info_MOD.js
@@ -8,7 +8,7 @@ class StoreAttachmentInfo {
   mod () {}
 
   subtitle ({ info }) {
-    const names = ["Attachment's URL", "Attachment File's Name", "ttachment's Height", "Attachment's Width", 'This option has been removed', "Attachment File's Size"]
+    const names = ["Attachment's URL", "Attachment File's Name", "Attachment's Height", "Attachment's Width", 'This option has been removed', "Attachment File's Size"]
     return `${names[parseInt(info)]}`
   }
 

--- a/events/message_reaction_added_EVT.js
+++ b/events/message_reaction_added_EVT.js
@@ -10,6 +10,7 @@ module.exports = {
     DBM.Events.reactionAdded = function (reaction, member) {
       if (!Bot.$evts['Message Reaction Added MOD']) return
       const server = reaction.message.guild || null
+      if (!server) return; // Stops the event since it's clearly being triggered in the DMs.
       const user = server.members.cache.get(member.id) || member
       for (const event of Bot.$evts['Message Reaction Added MOD']) {
         const temp = {}

--- a/events/message_reaction_removed_EVT.js
+++ b/events/message_reaction_removed_EVT.js
@@ -10,6 +10,7 @@ module.exports = {
     DBM.Events.reactionRemoved = function (reaction, member) {
       if (!Bot.$evts['Message Reaction Removed MOD']) return
       const server = reaction.message.guild || null
+      if (!server) return; // Stops the event since it's clearly being triggered in the DMs.
       for (const event of Bot.$evts['Message Reaction Removed MOD']) {
         const temp = {}
         if (event.temp) temp[event.temp] = reaction


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixed the EVT files from destroying the bot process when the reaction event is booted and the reaction originated in a Direct Message between the Bot and the User.

Also fixed grammar fixes to the Store Attachment Info.

**Status**

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [ ] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [x] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
