### PR TITLE
fix(events): DM reactions

### DIFF
--- a/events/message_reaction_added_EVT.js
+++ b/events/message_reaction_added_EVT.js
@@ -10,8 +10,10 @@ module.exports = {
     DBM.Events.reactionAdded = function (reaction, member) {
       if (!Bot.$evts['Message Reaction Added MOD']) return
       const server = reaction.message.guild || null
-      if (!server) return; // Stops the event since it's clearly being triggered in the DMs.
-      const user = server.members.cache.get(member.id) || member
+      let user = null
+      if (server) {
+        user = server.members.cache.get(member.id)
+      }
       for (const event of Bot.$evts['Message Reaction Added MOD']) {
         const temp = {}
         if (event.temp) temp[event.temp] = reaction

--- a/events/message_reaction_added_EVT.js
+++ b/events/message_reaction_added_EVT.js
@@ -10,7 +10,7 @@ module.exports = {
     DBM.Events.reactionAdded = function (reaction, member) {
       if (!Bot.$evts['Message Reaction Added MOD']) return
       const server = reaction.message.guild || null
-      let user = null
+      let user = member
       if (server) {
         user = server.members.cache.get(member.id)
       }

--- a/events/message_reaction_removed_EVT.js
+++ b/events/message_reaction_removed_EVT.js
@@ -10,11 +10,14 @@ module.exports = {
     DBM.Events.reactionRemoved = function (reaction, member) {
       if (!Bot.$evts['Message Reaction Removed MOD']) return
       const server = reaction.message.guild || null
-      if (!server) return; // Stops the event since it's clearly being triggered in the DMs.
+      let user = null
+      if (server) {
+        user = server.members.cache.get(member.id)
+      }
       for (const event of Bot.$evts['Message Reaction Removed MOD']) {
         const temp = {}
         if (event.temp) temp[event.temp] = reaction
-        if (event.temp2) temp[event.temp2] = server.members.cache.get(member.id) || member
+        if (event.temp2) temp[event.temp2] = user
         Actions.invokeEvent(event, server, temp)
       }
     }

--- a/events/message_reaction_removed_EVT.js
+++ b/events/message_reaction_removed_EVT.js
@@ -10,7 +10,7 @@ module.exports = {
     DBM.Events.reactionRemoved = function (reaction, member) {
       if (!Bot.$evts['Message Reaction Removed MOD']) return
       const server = reaction.message.guild || null
-      let user = null
+      let user = member
       if (server) {
         user = server.members.cache.get(member.id)
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Re-fix to #548. No longer stops, rather checks for existence of server and only then checks for the guild user.

**Status**

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [x] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
