### PR TITLE
Update file_control_MOD.js

### DIFF
--- a/actions/file_control_MOD.js
+++ b/actions/file_control_MOD.js
@@ -154,7 +154,7 @@ class FileControl {
     switch (task) {
       case 0: // Create File
         result = async () => {
-          if (fileName === '') return this.callNextAction(cache)
+          if (fileName === '') return
           fs.writeFileSync(fpath, '', (err) => {
             if (err) return console.log(`${lmg} creating: [${err}]`)
           })


### PR DESCRIPTION
Removing that cause the mod is already calling the next action, this is just causing it to call it twice when the file name is blank on "Create" (which is normal, it creates the directory)

**Please describe the changes this PR makes and why it should be merged:**
Fixes a bug in File Control.

**Status**

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [x] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
