### PR TITLE
Fix find_member.js

### DIFF
--- a/actions/find_member.js
+++ b/actions/find_member.js
@@ -126,8 +126,8 @@ module.exports = {
     const info = parseInt(data.info)
     const find = this.evalMessage(data.find, cache)
     const find2 = parseInt(data.find2)
-    if (server.memberCount !== server.members.cache.size) server.members.fetch()
-    const members = server.members.cache
+    if (server.memberCount !== server.members.size) server.members.fetch()
+    const members = server.members
     const users = this.getDBM().Bot.bot.users.cache
     let result
     switch (info) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When you use the find member action on discord.js 11.5.x the error `Cannot read property size of undefined` appears. I removed some cache functions so it works again
It should be merged to fix the issue so users can use the find member action again

**Status**

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [x] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
