### PR TITLE
opencollective-postinstall: Permission denied fix

### DIFF
--- a/events/cron_scheduler_EVT.js
+++ b/events/cron_scheduler_EVT.js
@@ -18,7 +18,7 @@ Timezone (<a href='#' onclick="require('child_process').execSync('start https://
     const { Bot, Actions } = DBM
 
     const Mods = Actions.getMods()
-    const cron = Mods.require('node-cron')
+    const cron = Mods.require('node-cron-no-open-collective')
 
     DBM.Events = DBM.Events || {}
 


### PR DESCRIPTION
### Please describe the changes this PR makes and why it should be merged:

If you wanted to host the bot on heroku there were problems with the latest published version of node-cron, as it uses opencollective-postinstall.
The error:
```
sh: 1: opencollective-postinstall: Permission denied
npm ERR! code ELIFECYCLEnpm ERR! errno 126npm 
ERR! node-cron@2.0.3 postinstall: `opencollective-postinstall`npm ERR! Exit status 126
```

There are already newer versions of [node-cron](https://github.com/node-cron/node-cron) without opencollective-postinstall. But these are not published. (Last release Sep. 2018, last commit Oct 2020)

A user has published a fork from the latest version. Here is the [issue ](https://github.com/node-cron/node-cron/issues/191)and here on the [npm page](https://www.npmjs.com/package/node-cron-no-open-collective).

Here I have now changed the `cron_schedule _EVT` to the package without opencollective-postinstall.


---------

### Status

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [x] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

### Semantic versioning classification:

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
