### PR TITLE
Enable Is Speaking? option in Check if member action

### DIFF
--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -133,7 +133,7 @@ module.exports = {
         break
       case 3:
         result = member.voice.speaking || false
-        break;
+        break
       case 4:
         result = !!this.dest(member.voice, 'channel')
         break

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -147,7 +147,7 @@ module.exports = {
         result = !!this.dest(member.voice, 'mute')
         break
       case 8:
-        result = this.dest(member.voice, 'deaf') || false
+        result = !!this.dest(member.voice, 'deaf')
         break
       case 9:
         result = member.id === msg.author.id

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -132,7 +132,7 @@ module.exports = {
         result = member.kickable
         break
       case 3:
-        result = member.voice.speaking || false
+        result = !!this.dest(member.voice, 'speaking')
         break
       case 4:
         result = !!this.dest(member.voice, 'channel')

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -144,7 +144,7 @@ module.exports = {
         result = member.id === Files.data.settings.ownerId
         break
       case 7:
-        result = this.dest(member.voice, 'mute') || false
+        result = !!this.dest(member.voice, 'mute')
         break
       case 8:
         result = this.dest(member.voice, 'deaf') || false

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -30,10 +30,10 @@ module.exports = {
       <option value="0" selected>Is Bot?</option>
       <option value="1">Is Bannable?</option>
       <option value="2">Is Kickable?</option>
-      <!-- option value="3">Is Speaking?</option --!>
+      <option value="3">Is Speaking?</option>
       <option value="4">Is In Voice Channel?</option>
       <option value="5">Is User Manageable?</option>
-          <option value="6">Is Bot Owner?</option>
+      <option value="6">Is Bot Owner?</option>
       <option value="7">Is Muted?</option>
       <option value="8">Is Deafened?</option>
       ${!isEvent && '<option value="9">Is Command Author?</option>'}
@@ -131,9 +131,9 @@ module.exports = {
       case 2:
         result = member.kickable
         break
-        // case 3:
-        // result = Boolean(member.speaking);
-        // break; //Do not ask me why this is not working... ~Lasse
+      case 3:
+        result = member.voice.speaking || false
+        break;
       case 4:
         result = !!this.dest(member.voice, 'channel')
         break
@@ -144,10 +144,10 @@ module.exports = {
         result = member.id === Files.data.settings.ownerId
         break
       case 7:
-        result = this.dest(member.voice, 'mute')
+        result = this.dest(member.voice, 'mute') || false
         break
       case 8:
-        result = this.dest(member.voice, 'deaf')
+        result = this.dest(member.voice, 'deaf') || false
         break
       case 9:
         result = member.id === msg.author.id


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- It enables `Is Speaking?` option
- It returns Boolean value for options that are expected to return Boolean

**Status**

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [ ] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [x] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
