### PR TITLE
Support Multiple Bot Owners extension in Check If Member

### DIFF
--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -149,7 +149,7 @@ module.exports = {
           result = member.id === Files.data.settings.ownerId
         } else {
           const botOwners = JSON.parse(fs.readFileSync(filePath, 'utf8'))
-          result = botOwners.includes(msg.author.id) || member.id === Files.data.settings.ownerId
+          result = botOwners.includes(member.id) || member.id === Files.data.settings.ownerId
         }
         break
       case 7:

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -120,6 +120,9 @@ module.exports = {
     const { Files } = this.getDBM()
     const { msg } = cache
 
+    const fs = require('fs')
+    const path = require('path')
+
     let result = false
     switch (info) {
       case 0:
@@ -141,7 +144,13 @@ module.exports = {
         result = member.manageable
         break
       case 6:
-        result = member.id === Files.data.settings.ownerId
+        const filepath = path.join(__dirname, '../data', 'multiple_bot_owners.json')
+        if (!fs.existsSync(filepath)) {
+          result = member.id === Files.data.settings.ownerId
+        } else {
+          const botOwners = JSON.parse(fs.readFileSync(filepath, 'utf8'))
+          result = botOwners.includes(msg.author.id) || msg.author.id === Files.data.settings.ownerId
+        }
         break
       case 7:
         result = !!this.dest(member.voice, 'mute')

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -142,8 +142,7 @@ module.exports = {
         break
       case 6:
         const fs = require('fs')
-        const path = require('path')
-        const filePath = path.join(__dirname, '../data', 'multiple_bot_owners.json')
+        const filePath = require('path').join(__dirname, '../data', 'multiple_bot_owners.json')
         if (!fs.existsSync(filePath)) {
           result = member.id === Files.data.settings.ownerId
         } else {

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -144,11 +144,11 @@ module.exports = {
         result = member.manageable
         break
       case 6:
-        const filepath = path.join(__dirname, '../data', 'multiple_bot_owners.json')
-        if (!fs.existsSync(filepath)) {
+        const filePath = path.join(__dirname, '../data', 'multiple_bot_owners.json')
+        if (!fs.existsSync(filePath)) {
           result = member.id === Files.data.settings.ownerId
         } else {
-          const botOwners = JSON.parse(fs.readFileSync(filepath, 'utf8'))
+          const botOwners = JSON.parse(fs.readFileSync(filePath, 'utf8'))
           result = botOwners.includes(msg.author.id) || msg.author.id === Files.data.settings.ownerId
         }
         break

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -149,7 +149,7 @@ module.exports = {
           result = member.id === Files.data.settings.ownerId
         } else {
           const botOwners = JSON.parse(fs.readFileSync(filePath, 'utf8'))
-          result = botOwners.includes(msg.author.id) || msg.author.id === Files.data.settings.ownerId
+          result = botOwners.includes(msg.author.id) || member.id === Files.data.settings.ownerId
         }
         break
       case 7:

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -120,9 +120,6 @@ module.exports = {
     const { Files } = this.getDBM()
     const { msg } = cache
 
-    const fs = require('fs')
-    const path = require('path')
-
     let result = false
     switch (info) {
       case 0:
@@ -144,6 +141,8 @@ module.exports = {
         result = member.manageable
         break
       case 6:
+        const fs = require('fs')
+        const path = require('path')
         const filePath = path.join(__dirname, '../data', 'multiple_bot_owners.json')
         if (!fs.existsSync(filePath)) {
           result = member.id === Files.data.settings.ownerId

--- a/actions/check_if_member_MOD.js
+++ b/actions/check_if_member_MOD.js
@@ -146,8 +146,7 @@ module.exports = {
         if (!fs.existsSync(filePath)) {
           result = member.id === Files.data.settings.ownerId
         } else {
-          const botOwners = JSON.parse(fs.readFileSync(filePath, 'utf8'))
-          result = botOwners.includes(member.id) || member.id === Files.data.settings.ownerId
+          result = JSON.parse(fs.readFileSync(filePath, 'utf8')).includes(member.id) || member.id === Files.data.settings.ownerId
         }
         break
       case 7:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Is Bot Owner?` option now checks if the member is one of the multiple owners

**Status**

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [ ] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
