### PR TITLE
Fix JSON decoding in Send JSON to WebAPI 

### DIFF
--- a/actions/send_json_to_webapi_MOD.js
+++ b/actions/send_json_to_webapi_MOD.js
@@ -211,7 +211,7 @@ module.exports = {
           }
         }
 
-        const jsonData = await fetch(url, { method, body: JSON.stringify(postJson), headers: setHeaders }).then((r) => r.json())
+        const jsonData = await fetch(url, { method, body: postJson, headers: setHeaders }).then((r) => r.json())
 
         try {
           if (jsonData) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
With previous version of code, it called JSON.stringify() on already JSON formed-string. This PR fixes this unintended behaviour.

**Status**

- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [ ] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
