### PR TITLE
Prevent Sharding Start Errors

### DIFF
--- a/sharder/sharded-bot.js
+++ b/sharder/sharded-bot.js
@@ -1,3 +1,4 @@
+  
 // Made by TheMonDon#1721
 // Some code by General Wrex
 const version = '1.1';
@@ -87,6 +88,7 @@ if (!token) {
   console.error("Token must be supplied in 'settings.json' in the data folder, double check your bot settings!");
 }
 
+// Create your ShardingManger instance
 const manager = new ShardingManager(startup, {
   // for ShardingManager options see:
   // https://discord.js.org/#/docs/main/stable/class/ShardingManager
@@ -96,4 +98,4 @@ const manager = new ShardingManager(startup, {
 
 manager.on('shardCreate', (shard) => console.log(`Shard ${shard.id} launched`));
 
-manager.spawn();
+manager.spawn(totalShards, 5500, -1); 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Sometimes some people may get this error when trying to start their sharded bot:
```shell
Error [SHARDING_READY_TIMEOUT]: Shard 0's Client took too long to become ready.?
```
This can be caused by a shard being in unavailable guilds, which completely stop bots from connecting.

In order to prevent this and future errors from happening to anyone the spawnTimeout can be set to -1 or Infinity: [more info](https://discord.js.org/#/docs/main/stable/class/ShardingManager?scrollTo=spawn)

* Prevent unavailable guilds from not letting a shard start
* Prevents a few other problems as well