### PR TITLE
Fix for Store Attachments Info mod [DBM v2]

### DIFF
--- a/actions/store_attachment_info_MOD.js
+++ b/actions/store_attachment_info_MOD.js
@@ -70,7 +70,7 @@ module.exports = {
     const message = this.getMessage(storage, varName, cache);
     const info = parseInt(data.info, 10);
 
-    const attachments = message.attachments.array();
+    const attachments = [...message.attachments.values()];
 
     if (attachments.length > 0) {
       const attachment = attachments[0];


### PR DESCRIPTION
Store Attachments Info errors 'message.attachments.array is not a function'. So i fixed it :/