### PR TITLE
Fix store twitch info on smaller displays

### DIFF
--- a/actions/store_twitch_info_MOD.js
+++ b/actions/store_twitch_info_MOD.js
@@ -257,7 +257,7 @@ module.exports = {
 
   html(isEvent, data) {
     return `
-<div id ="wrexdiv" style="width: 550px height: 350px overflow-y: scroll overflow-x: hidden">
+<div id="wrexdiv" style="width: 550px; height: 350px; overflow-y: scroll;">
   <div style="float: left width: 42%">
     <br>Source Type:<br>
     <select id="type" class="round" onchange="glob.onChange1(this)">


### PR DESCRIPTION

**Please describe the changes this PR makes and why it should be merged:**
The action store twitch info was previously not able to be saved on smaller displays without editing the action, as it had a scroll bar that didnt work, I have now added a working scroll bar so the action can now be saved on smaller displays without editing the action.
**Status**

- [➖ ] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [➖ ] Documentation has been added/modified, or there is nothing to change (docs/mods.json)
(Nothing API related changed within this PR)

**Semantic versioning classification:**

- [❌ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [❌ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
