### PR TITLE
Stop crashing if webhook can not be created in channel

### DIFF
--- a/actions/create_webhook_MOD.js
+++ b/actions/create_webhook_MOD.js
@@ -69,7 +69,7 @@ module.exports = {
     const varName = this.evalMessage(data.varName, cache);
     const channel = await this.getChannel(storage, varName, cache);
 
-    if (!channel && !channel.createWebhook) return this.callNextAction(cache);
+    if (!channel || !channel.createWebhook) return this.callNextAction(cache);
 
     const avatar = this.evalMessage(data.webhookIcon, cache);
     const name = this.evalMessage(data.webhookName, cache);

--- a/actions/create_webhook_MOD.js
+++ b/actions/create_webhook_MOD.js
@@ -69,7 +69,7 @@ module.exports = {
     const varName = this.evalMessage(data.varName, cache);
     const channel = await this.getChannel(storage, varName, cache);
 
-    if (!channel || !channel.createWebhook) return this.callNextAction(cache);
+    if (!channel?.createWebhook) return this.callNextAction(cache);
 
     const avatar = this.evalMessage(data.webhookIcon, cache);
     const name = this.evalMessage(data.webhookName, cache);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Stops bot crashing if webhook can not be created in channel. Amended if statement from using && to ||.

**Status**
- [x] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [x] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**
- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
