### PR TITLE
Convert time restriction to async to make it work on bot restarts

### DIFF
--- a/actions/set_time_restriction_MOD.js
+++ b/actions/set_time_restriction_MOD.js
@@ -196,7 +196,7 @@ module.exports = {
     }
 
     const TRData = cache.interaction ?? cache.msg;
-    const timeLeft = this.TimeRestriction(TRData, cmd, cache);
+    const timeLeft = await this.TimeRestriction(TRData, cmd, cache);
     if (!timeLeft) {
       this.executeResults(false, data, cache);
     } else {
@@ -207,10 +207,11 @@ module.exports = {
     }
   },
 
-  mod(DBM) {
+  async mod(DBM) {
     let Cooldown;
-    DBM.Actions.LoadTimeRestriction = function LoadTimeRestriction(cache) {
-      Cooldown = this.getVariable(3, 'DBMCooldown', cache);
+    DBM.Actions.LoadTimeRestriction = async function LoadTimeRestriction(cache) {
+      Cooldown = await this.getVariable(3, 'DBMCooldown', cache);
+
       if (typeof Cooldown === 'undefined') {
         Cooldown = {};
       } else if (typeof Cooldown === 'string') {
@@ -237,11 +238,11 @@ module.exports = {
       }
     };
 
-    DBM.Actions.TimeRestriction = function TimeRestriction(TRData, cmd, cache) {
+    DBM.Actions.TimeRestriction = async function TimeRestriction(TRData, cmd, cache) {
       const author = TRData.author ?? TRData.user;
       const { channel } = TRData;
 
-      if (typeof Cooldown === 'undefined') this.LoadTimeRestriction(cache);
+      if (typeof Cooldown === 'undefined') await this.LoadTimeRestriction(cache);
       const { Files } = DBM;
       let value = parseInt(this.evalMessage(cache.actions[cache.index].value, cache), 10);
       const measurement = parseInt(cache.actions[cache.index].measurement, 10);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes a long time issue with the mod that it was not working whenever the bot restarted, and by converting the loading functions to async it solves this issue.

Fixes #922 

**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [X] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
