### PR TITLE
Add emoji object to store reaction info

### DIFF
--- a/actions/store_reaction_info_MOD.js
+++ b/actions/store_reaction_info_MOD.js
@@ -19,6 +19,7 @@ module.exports = {
       'First User to React',
       'Random User to React',
       'Last User to React',
+      'Emoji Object',
     ];
     return `${presets.getVariableText(data.reaction, data.varName)} - ${info[parseInt(data.info, 10)]}`;
   },
@@ -50,6 +51,9 @@ module.exports = {
         break;
       case 7:
         dataType = 'User';
+        break;
+      case 8:
+        dataType = 'Object';
         break;
       default:
         break;
@@ -84,6 +88,7 @@ module.exports = {
       <option value="1">Bot Reacted?</option>
       <option value="2">User Who Reacted List</option>
       <option value="3">Emoji Name</option>
+      <option value="8">Emoji Object</option>
       <option value="4">Reaction Count</option>
     </select>
   </div>
@@ -152,6 +157,10 @@ module.exports = {
       case 7: {
         const lastid = rea.users.cache.lastKey(); // Stores last user ID reacted
         result = cache.server.members.cache.get(lastid);
+        break;
+      }
+      case 8: {
+        result = rea.emoji; // Emoji object
         break;
       }
       default:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allow users to get emoji object from reaction info rather than only the name.

**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [X] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
