### PR TITLE
Update Mods Module Installer to allow specific version

### DIFF
--- a/actions/aaa_dbmmods_dependencies_MOD.js
+++ b/actions/aaa_dbmmods_dependencies_MOD.js
@@ -3,12 +3,16 @@ const Mods = {
 
   async installModule(moduleName, version) {
     return new Promise((resolve) => {
-      version ? require('child_process').execSync(`npm i ${moduleName}@${version}`) : require('child_process').execSync(`npm i ${moduleName}`);
+      version
+        ? require('child_process').execSync(`npm i ${moduleName}@${version}`)
+        : require('child_process').execSync(`npm i ${moduleName}`);
       try {
         resolve(require(moduleName));
       } catch (error) {
-        console.log('If this is the first time installing the module, restart your bot first!\n\n')
-        console.error(`Failed to install ${version ? `${moduleName}@${version}` : moduleName}. Error: ${error.message}`);
+        console.log('If this is the first time installing the module, restart your bot first!\n\n');
+        console.error(
+          `Failed to install ${version ? `${moduleName}@${version}` : moduleName}. Error: ${error.message}`,
+        );
       }
     });
   },

--- a/actions/aaa_dbmmods_dependencies_MOD.js
+++ b/actions/aaa_dbmmods_dependencies_MOD.js
@@ -1,22 +1,23 @@
 const Mods = {
   DBM: null,
 
-  installModule(moduleName) {
+  async installModule(moduleName, version) {
     return new Promise((resolve) => {
-      require('child_process').execSync(`npm i ${moduleName}`);
+      version ? require('child_process').execSync(`npm i ${moduleName}@${version}`) : require('child_process').execSync(`npm i ${moduleName}`);
       try {
         resolve(require(moduleName));
       } catch (error) {
-        console.error(`Failed to install ${moduleName}. Error: ${error.message}`);
+        console.log('If this is the first time installing the module, restart your bot first!\n\n')
+        console.error(`Failed to install ${version ? `${moduleName}@${version}` : moduleName}. Error: ${error.message}`);
       }
     });
   },
 
-  require(moduleName) {
+  require(moduleName, version) {
     try {
       return require(moduleName);
     } catch (e) {
-      this.installModule(moduleName);
+      version ? this.installModule(moduleName, version) : this.installModule(moduleName);
       return require(moduleName);
     }
   },
@@ -136,6 +137,7 @@ const Mods = {
 
     /* eslint-enable */
   },
+
   getWebhook(type, varName, cache) {
     const { server } = cache;
     switch (type) {

--- a/actions/aaa_dbmmods_dependencies_MOD.js
+++ b/actions/aaa_dbmmods_dependencies_MOD.js
@@ -3,13 +3,13 @@ const Mods = {
 
   async installModule(moduleName, version) {
     return new Promise((resolve) => {
-      version
-        ? require('child_process').execSync(`npm i ${moduleName}@${version}`)
-        : require('child_process').execSync(`npm i ${moduleName}`);
+      require('child_process').execSync(`npm i ${version ? `${moduleName}@${version}` : moduleName}`);
       try {
         resolve(require(moduleName));
       } catch (error) {
-        console.log('If this is the first time installing the module, restart your bot first!\n\n');
+        console.log(
+          '\n\nIf this is the first time installing the module, restart your bot first! This is probably a false error.\n\n',
+        );
         console.error(
           `Failed to install ${version ? `${moduleName}@${version}` : moduleName}. Error: ${error.message}`,
         );

--- a/actions/aaa_dbmmods_dependencies_MOD.js
+++ b/actions/aaa_dbmmods_dependencies_MOD.js
@@ -1,7 +1,7 @@
 const Mods = {
   DBM: null,
 
-  async installModule(moduleName, version) {
+  installModule(moduleName, version) {
     return new Promise((resolve) => {
       require('child_process').execSync(`npm i ${version ? `${moduleName}@${version}` : moduleName}`);
       try {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This allows installing a specific version of a node module for example if something like discord-html-transcripts requires 2.6.1 for v13 of discord.js ;)

Also updated the error message as the module installs even though it still errors out, unsure why that happens, but its not new.
**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [X] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
