### PR TITLE
Action needs embed object not a message variable

### DIFF
--- a/actions/store_embed_info_MOD.js
+++ b/actions/store_embed_info_MOD.js
@@ -32,7 +32,7 @@ module.exports = {
   html() {
     return `
 <div>
-  <message-input dropdownLabel="Source Message" selectId="message" variableContainerId="varNameContainer" variableInputId="varName"></message-input>
+  <retrieve-from-variable dropdownLabel="Source Embed Object" selectId="message" variableContainerId="varNameContainer" variableInputId="varName"></retrieve-from-variable>
 </div>
 <br><br><br>
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Closes  #981, incorrectly changed from needing an embed object to message object. Changing source-message to retrieve-from-variable.
 
**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [X] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
