### PR TITLE
Revert change from data.lists to store-in-variable

### DIFF
--- a/actions/find_item_in_list_MOD.js
+++ b/actions/find_item_in_list_MOD.js
@@ -32,10 +32,19 @@ module.exports = {
 
   fields: ['list', 'varName', 'item', 'storage', 'varName2'],
 
-  html() {
+  html(isEvent, data) {
     return `
 <div>
-  <store-in-variable dropdownLabel="Source List" selectId="list" variableContainerId="varNameContainer" variableInputId="varName"></store-in-variable>
+	<div style="float: left; width: 35%;">
+		<span class="dbminputlabel">Source List</span>
+		<select id="list" class="round" onchange="glob.listChange(this, 'varNameContainer')">
+			${data.lists[isEvent ? 1 : 0]}
+		</select>
+	</div>
+	<div id="varNameContainer" style="display: none; float: right; width: 60%;">
+		<span class="dbminputlabel">Variable Name</span>
+		<input id="varName" class="round" type="text" list="variableList"><br>
+	</div>
 </div>
 <br><br><br>
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Should have been retrieve-from-variable but changing it back to what it was originally.. i'm not actually sure this matters but only shows lists in dropdown menu.

This unbreaks breaking changes, making new breaking changes, but people don't download mods very often.
**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [X] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
