### PR TITLE
Make set time restiction work with every command type

### DIFF
--- a/actions/set_time_restriction_MOD.js
+++ b/actions/set_time_restriction_MOD.js
@@ -246,10 +246,7 @@ module.exports = {
       const author = TRData.author ?? TRData.user;
       const { channel } = TRData;
 
-      if (typeof Cooldown === 'undefined' || Cooldown === {}) {
-        await this.LoadTimeRestriction(cache);
-        console.log('Cooldown', Cooldown);
-      }
+      if (typeof Cooldown === 'undefined' || Cooldown === {}) await this.LoadTimeRestriction(cache);
 
       const { Files } = DBM;
       let value = parseInt(await this.evalMessage(cache.actions[cache.index].value, cache), 10);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Time restriction mod will now work on every single command type, and also has a new added option for using days instead of hours. Also added the option to save the time left in nothing to make it look cleaner when you don't want to use that.

In the future it may even be possible to add events to it, or buttons/etc, but I didn't want to test that.
**Status**

- [X] Code changes have been tested against the Discord API and the discord.js wrapper, or there are no code changes
- [X] Documentation has been added/modified, or there is nothing to change (docs/mods.json)

**Semantic versioning classification:**

- [ ] This PR changes DBM's interface (methods or parameters added to default methods)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
